### PR TITLE
Add reviewers-number as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Automatically Merge PR Actions
-A GitHub Action to merge PR Autometically.
+A GitHub Action to automatically merge Pull Requests.
 
-If you put a specific label, the action will then check the number of reviews in PR.
+If you add a specific label, the action will then check the number of reviews.
 
 If the number of reviews is more than one, the PR is automatically merged.
 
-If you put other lables, the action will be passed.
+If you add other lables, the action will be passed.
 
 <!-- Screenshot -->
 
@@ -20,25 +20,33 @@ on:
       - develop/*       # The branch you want to automatically merge pull request
 jobs:
   Run Actions:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
     - name: Automatically Merge PR
-      uses: plm9606/automerge_actions@1.0.0
+      uses: plm9606/automerge_actions@1.1.0
       with:
-        # The PR label name you want to use when merge PR automatically.
-        label-name: # If you don't write it, default is automerge
+        # The label name to automatically merge. Default is "automerge".
+        label-name:
+        # The number of reviewers to automatically merge. Default is 1.
+        reviewers-number: 
         # GitHub WebHook Secret Token
         github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-## inputs
+## Inputs
 ### 1. label-name
 
-  It is not required.(default is `automerge`)
+  Not required, default is `automerge`.
   
-  You must put a label with this name. The action will then check the number of reviews in PR.
+  The label name the action uses to merge, before checking for reviews.
   
-### 2. github-token
+### 2. reviewers-number
+
+  Not required, default is `1`.
+  
+  The number of reviewers the action uses to merge, after checking the label.
+  
+### 3. github-token
 
   Required.
   You have to get `Personal access token` from GitHub. And create GitHub secrets in your repo.([How to?](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets))
@@ -50,4 +58,4 @@ jobs:
   
   `You don't labeled auto merge label::"${labelName}"`: If you intend to merge automatically, check the merge label name.
   
-  `You need to get other's review!` : Error. You must receive at least one review. 
+  `You need to get other's review!` : Error. You must receive PR review(s). 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: The PR label name you want to use when merge PR automatically.
     required: true
     default: "automerge"
+  reviewers-number:
+    description: Number of reviewers needed to automatically merge the PR.
+    required: false
+    default: "1"
   github-token:
     description: GitHub WebHook Secret Token
     required: true

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "Autometically Merge PR using custom PR label."
 inputs:
   label-name:
     description: The PR label name you want to use when merge PR automatically.
-    required: true
+    required: false
     default: "automerge"
   reviewers-number:
     description: Number of reviewers needed to automatically merge the PR.

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const tools = new Toolkit();
 async function autoMerge() {
   try {
     const labelName = core.getInput("label-name");
+    const reviewersNumber = core.getInput("reviewers-number");
     const myToken = core.getInput("github-token");
     const octokit = new github.GitHub(myToken);
 
@@ -25,7 +26,7 @@ async function autoMerge() {
     const hasAutomerge = labels.some(label => label.name === labelName);
 
     if (hasAutomerge) {
-      if (reviews.data.length > 0) {
+      if (reviews.data.length >= +reviewersNumber) {
         octokit.pulls.merge({
           ...github.context.repo,
           pull_number


### PR DESCRIPTION
I added the reviewers-number as a new input, default 1, to choose the number of reviews the PR should receive to get automatically merged.