### PR TITLE
feat: accepts trigger on PRs without label

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ async function autoMerge() {
     });
 
     const labels = pr.data.labels;
-    const hasAutomerge = labels.some((label) => label.name === labelName);
+    const hasAutomerge = labelName === "*" || labels.some((label) => label.name === labelName);
 
     if (hasAutomerge) {
       if (reviews.data.length >= +reviewersNumber) {
@@ -36,7 +36,7 @@ async function autoMerge() {
         });
         core.info(`Success Merge PR!`);
       } else throw Error("You need to get other's review!");
-    } else core.info(`You don't labeled auto merge label::"${labelName}"`);
+    } else core.info(`You didn't label this PR with auto merge label::"${labelName}"`);
 
     if (autoDelete.toUpperCase() === "TRUE") {
       core.info("The Bot will remove merged branch.");


### PR DESCRIPTION
using * as labelName will now trigger on all PR's, with or without label. also fixing some spelling